### PR TITLE
Install zsh and fish completions

### DIFF
--- a/Formula/todoist.rb
+++ b/Formula/todoist.rb
@@ -10,5 +10,8 @@ class Todoist < Formula
 
   def install
     system "go", "build", "-o", bin/"todoist"
+    
+    fish_completion.install "todoist_functions_fzf.sh"
+    zsh_completion.install "todoist_functions.sh" => "_todoist"
   end
 end


### PR DESCRIPTION
Manually installing shell completions can be a bit cumbersome when installing via homebrew. Luckily this can be automated. :)